### PR TITLE
[FEATURE] Render Supported Types and Values

### DIFF
--- a/lib/flash_rails_messages/base.rb
+++ b/lib/flash_rails_messages/base.rb
@@ -1,5 +1,12 @@
 module FlashRailsMessages
   class Base
+    TYPES = %i[
+      notice
+      success
+      alert
+      error
+    ].freeze
+
     include ActionView::Context
     include ActionView::Helpers::TagHelper
 
@@ -10,13 +17,22 @@ module FlashRailsMessages
     end
 
     def render(flash)
-      flash = Hash[flash].symbolize_keys
-      flash.map { |message| alert_element(*message) }.join.html_safe
+      messages(flash).map do |message|
+        alert_element(*message)
+      end.join.html_safe
     end
 
     private
 
+    def messages(flash)
+      Hash[flash]
+        .symbolize_keys
+        .keep_if { |key, _| TYPES.include?(key) }
+    end
+
     def alert_element(type, message)
+      return unless message.respond_to?(:html_safe)
+
       content_tag :div, alert_options(type) do
         content = ActiveSupport::SafeBuffer.new
         content += close_element if options.fetch(:dismissible, false)
@@ -58,7 +74,6 @@ module FlashRailsMessages
       {}
     end
 
-    def custom_alert_classes
-    end
+    def custom_alert_classes; end
   end
 end

--- a/lib/flash_rails_messages/base.rb
+++ b/lib/flash_rails_messages/base.rb
@@ -1,12 +1,5 @@
 module FlashRailsMessages
   class Base
-    TYPES = %i[
-      notice
-      success
-      alert
-      error
-    ].freeze
-
     include ActionView::Context
     include ActionView::Helpers::TagHelper
 
@@ -27,7 +20,7 @@ module FlashRailsMessages
     def messages(flash)
       Hash[flash]
         .symbolize_keys
-        .keep_if { |key, _| TYPES.include?(key) }
+        .keep_if { |key, _| alert_type_classes.include?(key) }
     end
 
     def alert_element(type, message)

--- a/spec/flash_rails_messages_spec.rb
+++ b/spec/flash_rails_messages_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe FlashRailsMessages::Helper do
   end
 
   describe '#render_flash_messages' do
+    before do
+      allow_any_instance_of(FlashRailsMessages::Base).to \
+        receive(:alert_type_classes)
+        .and_return(
+          success: 'framework-success',
+          notice: 'framework-notice',
+          alert: 'framework-alert',
+          error: 'framework-error'
+        )
+    end
+
     context 'when flash does not have messages' do
       it 'returns nothing' do
         allow(subject).to receive(:flash).and_return({})
@@ -21,7 +32,7 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when flash type is notice' do
         it 'returns the correct message' do
           allow(subject).to receive(:flash).and_return({ notice: 'message' })
-          alert_expected = alert_element('message', class: 'alert')
+          alert_expected = alert_element('message', class: 'alert framework-notice')
           expect(subject.render_flash_messages).to eql(alert_expected)
         end
       end
@@ -29,7 +40,7 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when flash type is success' do
         it 'returns the correct message' do
           allow(subject).to receive(:flash).and_return({ success: 'message' })
-          alert_expected = alert_element('message', class: 'alert')
+          alert_expected = alert_element('message', class: 'alert framework-success')
           expect(subject.render_flash_messages).to eql(alert_expected)
         end
       end
@@ -37,7 +48,7 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when flash type is alert' do
         it 'returns the correct message' do
           allow(subject).to receive(:flash).and_return({ alert: 'message' })
-          alert_expected = alert_element('message', class: 'alert')
+          alert_expected = alert_element('message', class: 'alert framework-alert')
           expect(subject.render_flash_messages).to eql(alert_expected)
         end
       end
@@ -45,7 +56,7 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when flash type is error' do
         it 'returns the correct message' do
           allow(subject).to receive(:flash).and_return({ error: 'message' })
-          alert_expected = alert_element('message', class: 'alert')
+          alert_expected = alert_element('message', class: 'alert framework-error')
           expect(subject.render_flash_messages).to eql(alert_expected)
         end
       end
@@ -67,8 +78,8 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when has more than one message' do
         it 'returns all the correct messages' do
           allow(subject).to receive(:flash).and_return({ alert: 'message1', notice: 'message2' })
-          alerts_expected = alert_element('message1', class: 'alert') +
-                            alert_element('message2', class: 'alert')
+          alerts_expected = alert_element('message1', class: 'alert framework-alert') +
+                            alert_element('message2', class: 'alert framework-notice')
           expect(subject.render_flash_messages).to eql(alerts_expected)
         end
       end
@@ -76,8 +87,8 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when has more than one message including unsupported value' do
         it 'returns all the correct messages' do
           allow(subject).to receive(:flash).and_return({ alert: 'message1', success: true, notice: 'message2' })
-          alerts_expected = alert_element('message1', class: 'alert') +
-                            alert_element('message2', class: 'alert')
+          alerts_expected = alert_element('message1', class: 'alert framework-alert') +
+                            alert_element('message2', class: 'alert framework-notice')
           expect(subject.render_flash_messages).to eql(alerts_expected)
         end
       end
@@ -85,8 +96,8 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'when has more than one message including unsupported type' do
         it 'returns all the correct messages' do
           allow(subject).to receive(:flash).and_return({ alert: 'message1', bogus: 'entry', notice: 'message2' })
-          alerts_expected = alert_element('message1', class: 'alert') +
-                            alert_element('message2', class: 'alert')
+          alerts_expected = alert_element('message1', class: 'alert framework-alert') +
+                            alert_element('message2', class: 'alert framework-notice')
           expect(subject.render_flash_messages).to eql(alerts_expected)
         end
       end
@@ -94,7 +105,7 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'with dismissible option' do
         it 'returns the correct message' do
           allow(subject).to receive(:flash).and_return({ notice: 'message' })
-          alert_expected = alert_dismissible_element('message', class: 'alert')
+          alert_expected = alert_dismissible_element('message', class: 'alert framework-notice')
           expect(subject.render_flash_messages(dismissible: true)).to eql(alert_expected)
         end
       end
@@ -102,7 +113,7 @@ RSpec.describe FlashRailsMessages::Helper do
       context 'with other options' do
         it 'returns the correct message' do
           allow(subject).to receive(:flash).and_return({ notice: 'message' })
-          alert_expected = alert_element('message', id: 'alert-id', class: 'alert alert-class')
+          alert_expected = alert_element('message', id: 'alert-id', class: 'alert framework-notice alert-class')
           expect(subject.render_flash_messages(id: 'alert-id', class: 'alert-class')).to eql(alert_expected)
         end
       end

--- a/spec/flash_rails_messages_spec.rb
+++ b/spec/flash_rails_messages_spec.rb
@@ -50,9 +50,41 @@ RSpec.describe FlashRailsMessages::Helper do
         end
       end
 
+      context 'when flash message value is unsupported' do
+        it 'returns nothing' do
+          allow(subject).to receive(:flash).and_return({ notice: true })
+          expect(subject.render_flash_messages).to be_blank
+        end
+      end
+
+      context 'when flash type is of unsupported type' do
+        it 'returns nothing' do
+          allow(subject).to receive(:flash).and_return({ other: true })
+          expect(subject.render_flash_messages).to be_blank
+        end
+      end
+
       context 'when has more than one message' do
         it 'returns all the correct messages' do
           allow(subject).to receive(:flash).and_return({ alert: 'message1', notice: 'message2' })
+          alerts_expected = alert_element('message1', class: 'alert') +
+                            alert_element('message2', class: 'alert')
+          expect(subject.render_flash_messages).to eql(alerts_expected)
+        end
+      end
+
+      context 'when has more than one message including unsupported value' do
+        it 'returns all the correct messages' do
+          allow(subject).to receive(:flash).and_return({ alert: 'message1', success: true, notice: 'message2' })
+          alerts_expected = alert_element('message1', class: 'alert') +
+                            alert_element('message2', class: 'alert')
+          expect(subject.render_flash_messages).to eql(alerts_expected)
+        end
+      end
+
+      context 'when has more than one message including unsupported type' do
+        it 'returns all the correct messages' do
+          allow(subject).to receive(:flash).and_return({ alert: 'message1', bogus: 'entry', notice: 'message2' })
           alerts_expected = alert_element('message1', class: 'alert') +
                             alert_element('message2', class: 'alert')
           expect(subject.render_flash_messages).to eql(alerts_expected)


### PR DESCRIPTION
Only attempt to render flash keys of `notice`, `success`, `alert`, and `error`. 

Also ensures that only keys with `html_safe` values are included.